### PR TITLE
Ensure faraday is required before defining the adapter

### DIFF
--- a/lib/faraday/adapter/typhoeus.rb
+++ b/lib/faraday/adapter/typhoeus.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'faraday'
 require 'typhoeus'
 
 module Faraday

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'faraday'
 require 'rack'
 require 'faraday/typhoeus'
 # This is the magic bit. It requires a tests suite from the Faraday gem that you can run against your adapter


### PR DESCRIPTION
Without this, depending on the require order of things in your app (and if `faraday` hasn't been required before `faraday/typhoeus`), then you could hit an error like this:

```
faraday/adapter/typhoeus.rb:8:in `<class:Typhoeus>': undefined method `supports_parallel=' for Faraday::Adapter::Typhoeus:Class (NoMethodError)
```

Because if `faraday` hasn't been required first, then what's happening is `Faraday::Adapter` is being defined for the first time in `lib/faraday/adapter/typhoeus.rb`. But it's an empty class, so when you then inherit from `Faraday::Adapter`, you're actually inheriting from a new, empty class where it doesn't knot anything about `supports_parallel` (which is defined only defined in faraday's implementation of this base class).

So by ensuring `faraday` is always required first, this solves this potential ordering issues around dependencies so that it's always inheriting from the expected `Faraday::Adapter` implementation from the `faraday` gem.