### PR TITLE
better non-bundler instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ And then execute:
 
     $ bundle install
 
-Or install it yourself as:
-
-    $ gem install faraday-typhoeus
+Or install it yourself with `gem install faraday-typhoeus` and require it in your ruby code with `require 'faraday/typhoeus'`
 
 ## Usage
 


### PR DESCRIPTION
Make it clear what you have to require, since it's different than the gem name. Mostly relevant if not using bundler/`Bundler.require`.

see #4, #5