### PR TITLE
feat: expose libcurl timings in the faraday env

### DIFF
--- a/lib/faraday/adapter/typhoeus.rb
+++ b/lib/faraday/adapter/typhoeus.rb
@@ -92,10 +92,10 @@ module Faraday
             end
           end
 
-          env[:typhoeus_timings] = %w[
+          env[:typhoeus_timings] = %i[
             appconnect connect namelookup pretransfer redirect starttransfer total
           ].to_h do |key|
-            [key.to_sym, resp.public_send("#{key}_time")]
+            [key, resp.public_send("#{key}_time")]
           end
 
           save_response(env, resp.code, resp.body, nil, resp.status_message) do |response_headers|

--- a/lib/faraday/adapter/typhoeus.rb
+++ b/lib/faraday/adapter/typhoeus.rb
@@ -92,6 +92,10 @@ module Faraday
             end
           end
 
+          env[:typhoeus_timings] = %w[appconnect connect namelookup pretransfer redirect starttransfer total].map do |key|
+            [key, resp.send("#{key}_time")]
+          end.to_h
+
           save_response(env, resp.code, resp.body, nil, resp.status_message) do |response_headers|
             response_headers.parse resp.response_headers
           end

--- a/lib/faraday/adapter/typhoeus.rb
+++ b/lib/faraday/adapter/typhoeus.rb
@@ -92,9 +92,11 @@ module Faraday
             end
           end
 
-          env[:typhoeus_timings] = %w[appconnect connect namelookup pretransfer redirect starttransfer total].map do |key|
-            [key, resp.send("#{key}_time")]
-          end.to_h
+          env[:typhoeus_timings] = %w[
+            appconnect connect namelookup pretransfer redirect starttransfer total
+          ].to_h do |key|
+            [key.to_sym, resp.public_send("#{key}_time")]
+          end
 
           save_response(env, resp.code, resp.body, nil, resp.status_message) do |response_headers|
             response_headers.parse resp.response_headers

--- a/spec/faraday/adapter/typhoeus_spec.rb
+++ b/spec/faraday/adapter/typhoeus_spec.rb
@@ -305,6 +305,20 @@ RSpec.describe Faraday::Adapter::Typhoeus do
       it 'succeeds' do
         expect(conn.get('/').status).to be(200)
       end
+
+      it 'sets timings' do
+        response = conn.get('/')
+        # TODO: make these not-nil after https://github.com/bblimke/webmock/pull/1038 lands
+        expect(response.env.custom_members[:typhoeus_timings]).to eq({
+                                                                       appconnect: nil,
+                                                                       connect: nil,
+                                                                       namelookup: nil,
+                                                                       pretransfer: nil,
+                                                                       redirect: nil,
+                                                                       starttransfer: nil,
+                                                                       total: nil
+                                                                     })
+      end
     end
 
     context 'failed connection' do


### PR DESCRIPTION
This collects all of the detailed timings from libcurl (via Typhoeus) and exposes them as `response.env.custom_members[:typhoeus_timings]`. We're using this internally, and I thought other folks might find it helpful, too.

Example:

```
[1] pry(main)> resp = Faraday.new { |b| b.adapter :typhoeus }.get "https://www.example.com"
ETHON: Libcurl initialized
ETHON: performed EASY effective_url=https://www.example.com/ response_code=200 return_code=ok total_time=0.082656
[2] pry(main)> puts resp.env.custom_members[:typhoeus_timings]
{"appconnect"=>0.063223, "connect"=>0.023084, "namelookup"=>0.005523, "pretransfer"=>0.06355, "redirect"=>0.0, "starttransfer"=>0.081755, "total"=>0.082656}
```